### PR TITLE
Add formulation selection for medications

### DIFF
--- a/dailyLogConfig.md
+++ b/dailyLogConfig.md
@@ -2,10 +2,8 @@
 {
   "medDefaults": {
     "ODB Formulary": {
-      "TRINTELLIX 5MG": { "dose": "5mg", "unit": "tablets" },
-      "TRINTELLIX 10MG": { "dose": "10mg", "unit": "tablets" },
-      "VYVANSE 20MG": { "dose": "20mg", "unit": "tablets" },
-      "VYVANSE 40MG": { "dose": "40mg", "unit": "tablets" }
+      "Vyvanse (Brand)": { "Formulations": ["40mg Capsule", "60mg Capsule"] },
+      "Trintellix (Brand)": { "Formulations": ["5mg Tablet", "10mg Tablet"] }
     },
     "IndiaMART": [
       "SIZODON® MD 0.5",

--- a/dailyLogTemplater.js
+++ b/dailyLogTemplater.js
@@ -101,11 +101,20 @@ if (firstPick === "Medication") {
     const medChoice = await tp.system.suggester(meds, meds);
     let entry = medChoice;
     if (!Array.isArray(medGroup)) {
-      const qtyInput = await tp.system.prompt("Quantity (dec / fraction)", "1");
-      const qty = parseQty(qtyInput);
-      if (qty !== 1 && !isNaN(qty) && qty !== 0) {
-        const { dose, unit } = medGroup[medChoice];
-        entry = `${medChoice} (${dose} x ${qty} ${unit})`;
+      const info = medGroup[medChoice];
+      if (info && Array.isArray(info.Formulations)) {
+        const formChoice = await tp.system.suggester(info.Formulations, info.Formulations);
+        const qtyInput = await tp.system.prompt("Quantity (dec / fraction)", "1");
+        const qty = parseQty(qtyInput);
+        const qtyPart = (qty !== 1 && !isNaN(qty) && qty !== 0) ? ` x ${qty}` : "";
+        entry = `${medChoice} (${formChoice}${qtyPart})`;
+      } else {
+        const qtyInput = await tp.system.prompt("Quantity (dec / fraction)", "1");
+        const qty = parseQty(qtyInput);
+        if (qty !== 1 && !isNaN(qty) && qty !== 0) {
+          const { dose, unit } = info;
+          entry = `${medChoice} (${dose} x ${qty} ${unit})`;
+        }
       }
     }
     selected.push(entry);


### PR DESCRIPTION
## Summary
- simplify medication defaults to group formulations under each drug
- prompt for formulation and quantity when logging medications

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894ff0d55f483298a71639aba50a6d0